### PR TITLE
[SR-5213] Bump actions for Node 20 (and test with the same)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+---
+
+version: 2
+
+registries:
+  npm-artifactory:
+    type: npm-registry
+    url: https://artifactory.rtr.cloud/artifactory/api/npm/npm/
+    username: ${{ secrets.ARTIFACTORY_DEPLOY_USER }}
+    password: ${{ secrets.ARTIFACTORY_DEPLOY_PASSWORD }}
+
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    rebase-strategy: "disabled"
+    registries:
+      - npm-artifactory
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    rebase-strategy: "disabled"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,15 +7,15 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node: ['10.x', '12.x', '14.x']
+        node: ['10.x', '12.x', '14.x', '20.x']
         os: [ubuntu-latest, windows-latest, macOS-latest]
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Use Node ${{ matrix.node }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,25 @@ jobs:
     strategy:
       matrix:
         node: ['10', '12', '14', '20']
-        os: [ubuntu-latest, windows-latest, macOS-latest]
+        include:
+          - node: '10'
+            os: 'ubuntu-latest'
+          - node: '10'
+            os: 'windows-latest'
+          - node: '12'
+            os: 'ubuntu-latest'
+          - node: '12'
+            os: 'windows-latest'
+          - node: '14'
+            os: 'ubuntu-latest'
+          - node: '14'
+            os: 'windows-latest'
+          - node: '20'
+            os: 'ubuntu-latest'
+          - node: '20'
+            os: 'windows-latest'
+          - node: '20'
+            os: 'macos-latest'
 
     steps:
       - name: Checkout repo

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node: ['10.x', '12.x', '14.x', '20.x']
+        node: ['10', '12', '14', '20']
         os: [ubuntu-latest, windows-latest, macOS-latest]
 
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node: ['10', '12', '14', '20']
         include:
           - node: '10'
             os: 'ubuntu-latest'


### PR DESCRIPTION
- Bump GitHub Actions for Node 20 used on runners
- Add Node 20 to the tested versions
- Node 14 support for ARM64 versions of MacOS was experimental, with no support from earlier versions, so only test on MacOS with Node 20